### PR TITLE
allow version greater than node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"package.json"
 	],
 	"engines": {
-		"node": "^6.0.0"
+		"node": ">=6.0.0"
 	},
 	"scripts": {
 		"test": "echo `Successfully tested!`"


### PR DESCRIPTION
Now that node 8 is LTE, I would like to allow to download it with yarn.
Right now Yarn throw me an error:
<img width="736" alt="screen shot 2017-11-05 at 22 58 43" src="https://user-images.githubusercontent.com/13608477/32415409-f084f38c-c27c-11e7-8856-0b99846d65a4.png">

Will be good if it could be deploy on npm asap :)